### PR TITLE
リファクタリング: main.pyを薄いCLIエントリポイントとパイプラインモジュールに分割

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,14 +1,147 @@
-import yaml
-from pathlib import Path
+from __future__ import annotations
 
-def load_config(config_path: str = "config.yaml") -> dict:
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pydantic import BaseModel, Field, field_validator
+
+
+# ---------------------------------------------------------------------------
+# Section models
+# ---------------------------------------------------------------------------
+
+class LLMConfig(BaseModel):
+    model_config = {"extra": "forbid"}
+
+    base_url: str = "http://127.0.0.1:11434/v1"
+    model: str
+    api_key: str = "ollama"
+    parameters: dict[str, Any] = Field(default_factory=dict)
+    extra_body: dict[str, Any] | None = None
+    thinking: bool | None = None
+    gemma4_think: bool = False
+    disable_temperature_with_thinking: bool = False
+    max_retries: int = 3
+    structured_output: bool = True
+    embedding_model: str | None = None
+
+
+class SummarizerStepConfig(BaseModel):
+    model_config = {"extra": "forbid"}
+
+    parameters: dict[str, Any] | None = Field(default=None)
+    thinking: bool | None = None
+    use_embeddings: bool = False
+    similarity_threshold: float = 0.85
+
+
+class SummarizerConfig(BaseModel):
+    model_config = {"extra": "forbid"}
+
+    individual_max_length: int = 200
+    digest_max_length: int = 1500
+    categories: list[str] = Field(default_factory=list)
+    steps: dict[str, SummarizerStepConfig] = Field(default_factory=dict)
+
+    @field_validator("steps", mode="before")
+    @classmethod
+    def _coerce_null_steps(cls, v: Any) -> Any:
+        """YAML の完全コメントアウトされたステップ（null）をデフォルト設定に変換する。"""
+        if isinstance(v, dict):
+            return {k: (val if val is not None else {}) for k, val in v.items()}
+        return v
+
+
+class DatabaseConfig(BaseModel):
+    model_config = {"extra": "forbid"}
+
+    path: str = "data/news_summarizer.db"
+
+
+class MinifluxConfig(BaseModel):
+    model_config = {"extra": "forbid"}
+
+    base_url: str
+    api_key: str
+
+
+class EmailConfig(BaseModel):
+    model_config = {"extra": "forbid"}
+
+    host: str
+    port: int = 995
+    username: str
+    password: str
+    use_ssl: bool = True
+
+
+class DiscordConfig(BaseModel):
+    model_config = {"extra": "forbid"}
+
+    webhook_url: str | None = None
+    embed_color: int = 0x58B9C2
+    footer_text: str = ""
+    post_individual_articles: bool = True
+
+
+class LoggingConfig(BaseModel):
+    model_config = {"extra": "forbid"}
+
+    level: str = "INFO"
+
+
+# ---------------------------------------------------------------------------
+# Top-level app config
+# ---------------------------------------------------------------------------
+
+class AppConfig(BaseModel):
+    # extra="ignore" at the top level allows unknown sections (e.g. future additions)
+    # without raising errors. Inner models still use extra="forbid" to catch typos.
+    model_config = {"extra": "ignore"}
+
+    llm: LLMConfig
+    summarizer: SummarizerConfig = Field(default_factory=SummarizerConfig)
+    database: DatabaseConfig = Field(default_factory=DatabaseConfig)
+    miniflux: MinifluxConfig | None = None
+    email: EmailConfig | None = None
+    discord: DiscordConfig = Field(default_factory=DiscordConfig)
+    logging: LoggingConfig = Field(default_factory=LoggingConfig)
+
+
+# ---------------------------------------------------------------------------
+# Loader
+# ---------------------------------------------------------------------------
+
+def load_config(config_path: str = "config.yaml") -> AppConfig:
+    """Load and validate configuration from a YAML file.
+
+    Raises FileNotFoundError if the file does not exist, and
+    pydantic.ValidationError (with clear field-level messages) if the
+    content does not match the expected schema.
+    """
     path = Path(config_path)
     if not path.exists():
-        # Fallback to default structure or raise error
-        raise FileNotFoundError(f"Configuration file {config_path} not found.")
-    
-    with open(path, "r", encoding="utf-8") as f:
-        return yaml.safe_load(f)
+        raise FileNotFoundError(f"Configuration file '{config_path}' not found.")
 
-# デフォルト設定をロード
-config = load_config()
+    with open(path, "r", encoding="utf-8") as f:
+        raw: dict = yaml.safe_load(f) or {}
+
+    return AppConfig.model_validate(raw)
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton
+# ---------------------------------------------------------------------------
+
+# Loaded once at import time from the default config.yaml.
+# Callers that need to reload (e.g. --config CLI flag) should call
+# reload_config() which updates this module attribute in-place.
+config: AppConfig = load_config()
+
+
+def reload_config(config_path: str) -> AppConfig:
+    """Reload configuration from *config_path* and replace the module singleton."""
+    global config
+    config = load_config(config_path)
+    return config

--- a/fetchers/email_fetcher.py
+++ b/fetchers/email_fetcher.py
@@ -23,12 +23,14 @@ def strip_tags(html: str) -> str:
 
 class EmailFetcher(BaseFetcher):
     def __init__(self, db: Database):
-        email_cfg = config["email"]
-        self.host = email_cfg["host"]
-        self.port = email_cfg.get("port", 995)
-        self.username = email_cfg["username"]
-        self.password = email_cfg["password"]
-        self.use_ssl = email_cfg.get("use_ssl", True)
+        if config.email is None:
+            raise ValueError("email の設定が config.yaml に見つかりません。")
+        email_cfg = config.email
+        self.host = email_cfg.host
+        self.port = email_cfg.port
+        self.username = email_cfg.username
+        self.password = email_cfg.password
+        self.use_ssl = email_cfg.use_ssl
         self.db = db
 
     def fetch(self) -> List[Article]:

--- a/fetchers/rss_fetcher.py
+++ b/fetchers/rss_fetcher.py
@@ -10,9 +10,11 @@ logger = get_logger(__name__)
 
 class MinifluxFetcher(BaseFetcher):
     def __init__(self):
-        miniflux_cfg = config["miniflux"]
-        self.base_url = miniflux_cfg["base_url"]
-        self.api_key = miniflux_cfg["api_key"]
+        if config.miniflux is None:
+            raise ValueError("miniflux の設定が config.yaml に見つかりません。")
+        miniflux_cfg = config.miniflux
+        self.base_url = miniflux_cfg.base_url
+        self.api_key = miniflux_cfg.api_key
         self.headers = {
             "X-Auth-Token": self.api_key
         }

--- a/fetchers/rss_fetcher.py
+++ b/fetchers/rss_fetcher.py
@@ -9,12 +9,13 @@ from logger import get_logger
 logger = get_logger(__name__)
 
 class MinifluxFetcher(BaseFetcher):
-    def __init__(self):
+    def __init__(self, dry_run: bool = False):
         if config.miniflux is None:
             raise ValueError("miniflux の設定が config.yaml に見つかりません。")
         miniflux_cfg = config.miniflux
         self.base_url = miniflux_cfg.base_url
         self.api_key = miniflux_cfg.api_key
+        self.dry_run = dry_run
         self.headers = {
             "X-Auth-Token": self.api_key
         }
@@ -70,6 +71,9 @@ class MinifluxFetcher(BaseFetcher):
         return articles
 
     def _mark_as_read(self, entry_ids: List[int]):
+        if self.dry_run:
+            logger.info("[Dry-Run] 既読化をスキップしました")
+            return
         url = f"{self.base_url}/v1/entries"
         payload = {
             "entry_ids": entry_ids,

--- a/logger.py
+++ b/logger.py
@@ -6,7 +6,7 @@ from config import config
 
 def setup_logging() -> None:
     """ロギングシステムを初期化する。config.yaml の logging.level を参照する。"""
-    level_str = config.get("logging", {}).get("level", "INFO").upper()
+    level_str = config.logging.level.upper()
     level = getattr(logging, level_str, logging.INFO)
 
     handler = logging.StreamHandler(sys.stderr)

--- a/main.py
+++ b/main.py
@@ -3,8 +3,8 @@ import argparse
 import numpy as np
 from tqdm import tqdm
 
-from config import load_config
 import config as config_module
+from config import reload_config
 from logger import setup_logging, get_logger
 
 from outputs.database import Database
@@ -29,7 +29,7 @@ def main():
 
     # 設定の再読み込み
     if args.config != "config.yaml":
-        config_module.config.update(load_config(args.config))
+        reload_config(args.config)
 
     setup_logging()
     logger.info("プロセス開始")
@@ -84,10 +84,10 @@ def main():
     embeddings: np.ndarray | None = None
     article_group_map: dict[int, tuple] = {}
 
-    from summarizer.llm_client import _get_llm_config, get_step_config
+    from summarizer.llm_client import get_step_config
     step_cfg = get_step_config("grouper")
-    use_embeddings = step_cfg.get("use_embeddings", False)
-    embedding_model = _get_llm_config().get("embedding_model")
+    use_embeddings = step_cfg.use_embeddings
+    embedding_model = config_module.config.llm.embedding_model
 
     if use_embeddings and embedding_model:
         logger.info("Embedding を取得中...")

--- a/main.py
+++ b/main.py
@@ -1,168 +1,65 @@
 import argparse
 
-import numpy as np
-from tqdm import tqdm
-
 import config as config_module
 from config import reload_config
-from logger import setup_logging, get_logger
+from logger import setup_logging
+from pipeline import RunOptions, run_pipeline
 
-from outputs.database import Database
-from outputs.discord_output import DiscordOutput
-from fetchers.rss_fetcher import MinifluxFetcher
-from fetchers.email_fetcher import EmailFetcher
-from summarizer.grouper import group_articles, group_summaries
-from summarizer.summarizer import summarize_article
-from summarizer.digest import generate_digest
-
-logger = get_logger(__name__)
 
 def main():
     parser = argparse.ArgumentParser(description="AI News Summarizer")
-    parser.add_argument("--dry-run", action="store_true", help="ドライラン（Discord出力や既読化、DB保存を行わない）")
-    parser.add_argument("--output", type=str, choices=["discord", "db", "all"], nargs="+", help="ドライラン中でも強制的に出力するターゲット（例: --output discord）")
-    parser.add_argument("--source", type=str, choices=["rss", "email", "all"], default="all", help="取得先ソースの指定")
-    parser.add_argument("--config", type=str, default="config.yaml", help="設定ファイルのパス")
-    parser.add_argument("--stream", action="store_true", help="LLMの出力をストリーミング表示する（デバッグ用）")
-    parser.add_argument("--debug", action="store_true", help="embedding・類似度判定の詳細情報を表示する（デバッグ用）")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="ドライラン（Discord出力や既読化、DB保存を行わない）",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        choices=["discord", "db", "all"],
+        nargs="+",
+        help="ドライラン中でも強制的に出力するターゲット（例: --output discord）",
+    )
+    parser.add_argument(
+        "--source",
+        type=str,
+        choices=["rss", "email", "all"],
+        default="all",
+        help="取得先ソースの指定",
+    )
+    parser.add_argument(
+        "--config",
+        type=str,
+        default="config.yaml",
+        help="設定ファイルのパス",
+    )
+    parser.add_argument(
+        "--stream",
+        action="store_true",
+        help="LLMの出力をストリーミング表示する（デバッグ用）",
+    )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="embedding・類似度判定の詳細情報を表示する（デバッグ用）",
+    )
     args = parser.parse_args()
 
-    # 設定の再読み込み
     if args.config != "config.yaml":
         reload_config(args.config)
 
     setup_logging()
-    logger.info("プロセス開始")
 
-    db = Database()
+    options = RunOptions(
+        dry_run=args.dry_run,
+        forced_outputs=frozenset(args.output) if args.output else frozenset(),
+        sources=frozenset({args.source}),
+        stream=args.stream,
+        debug=args.debug,
+    )
 
-    # 記事取得
-    articles = []
-    if args.source in ["all", "rss"]:
-        try:
-            logger.info("RSS（Miniflux）から記事を取得中...")
-            rss_fetcher = MinifluxFetcher()
-            if args.dry_run:
-                rss_fetcher._mark_as_read = lambda x: logger.info("[Dry-Run] 既読化をスキップしました")
-            articles.extend(rss_fetcher.fetch())
-        except Exception as e:
-            logger.error("RSSの取得中にエラーが発生しました: %s", e, exc_info=True)
+    run_pipeline(config_module.config, options)
 
-    if args.source in ["all", "email"]:
-        try:
-            logger.info("Email（POP3）から記事を取得中...")
-            email_fetcher = EmailFetcher(db)
-            articles.extend(email_fetcher.fetch())
-        except Exception as e:
-            logger.error("Emailの取得中にエラーが発生しました: %s", e, exc_info=True)
-
-    if not articles:
-        logger.info("新規記事はありませんでした。処理を終了します。")
-        return
-
-    logger.info("%d件の新規記事を取得しました。", len(articles))
-
-    # 個別記事要約
-    pairs = []  # list of (Article, ArticleSummary)
-    if args.stream:
-        logger.info("個別記事の要約を行っています...")
-        articles_iter = articles
-    else:
-        articles_iter = tqdm(articles, desc="記事を要約中", unit="件")
-    for article in articles_iter:
-        try:
-            summary = summarize_article(article, stream=args.stream)
-            pairs.append((article, summary))
-        except Exception as e:
-            logger.error("記事要約中にエラーが発生しました (ID: %s): %s", article.source_id, e, exc_info=True)
-
-    if not pairs:
-        logger.warning("要約に成功した記事がありませんでした。処理を終了します。")
-        return
-
-    # embedding 取得 + グルーピング
-    embeddings: np.ndarray | None = None
-    article_group_map: dict[int, tuple] = {}
-
-    from summarizer.llm_client import get_step_config
-    step_cfg = get_step_config("grouper")
-    use_embeddings = step_cfg.use_embeddings
-    embedding_model = config_module.config.llm.embedding_model
-
-    if use_embeddings and embedding_model:
-        logger.info("Embedding を取得中...")
-        try:
-            from summarizer.embedder import get_embeddings
-            texts = [f"{s.title} {s.summary}" for _, s in pairs]
-            embeddings = get_embeddings(texts, debug=args.debug)
-
-            logger.info("類似記事の統合を行っています（embedding）...")
-            only_summaries = [s for _, s in pairs]
-            grouping_result = group_summaries(only_summaries, embeddings, stream=args.stream, debug=args.debug)
-            for group in grouping_result.groups:
-                for idx in group.article_indices:
-                    article_group_map[idx] = (group.group_id, group.topic)
-        except Exception as e:
-            logger.error("Embedding グルーピング中にエラーが発生しました: %s", e, exc_info=True)
-            embeddings = None
-            article_group_map = {}
-    else:
-        logger.info("類似記事の統合を行っています...")
-        try:
-            grouping_result = group_articles(articles, stream=args.stream)
-            for group in grouping_result.groups:
-                for idx in group.article_indices:
-                    article_group_map[idx] = (group.group_id, group.topic)
-        except Exception as e:
-            logger.error("類似記事統合中にエラーが発生しました: %s", e, exc_info=True)
-            article_group_map = {}
-
-    # group 情報を付与した summaries リストを構築
-    summaries = []
-    for i, (article, summary) in enumerate(pairs):
-        group_info = article_group_map.get(i, (None, None))
-        summaries.append((article, summary, group_info[0], group_info[1]))
-
-    # ダイジェスト生成
-    logger.info("ダイジェストを生成しています...")
-    only_summaries = [s[1] for s in summaries]
-    try:
-        digest = generate_digest(only_summaries, stream=args.stream)
-    except Exception as e:
-        logger.error("ダイジェスト生成中にエラーが発生しました: %s", e, exc_info=True)
-        return
-
-    # 出力処理
-    logger.info("結果を保存・出力しています...")
-
-    forced_outputs = set(args.output) if args.output else set()
-    run_db = not args.dry_run or "db" in forced_outputs or "all" in forced_outputs
-    run_discord = not args.dry_run or "discord" in forced_outputs or "all" in forced_outputs
-
-    if run_db:
-        batch_id = db.create_batch(total_articles=len(only_summaries), digest_text=digest.overview)
-        for i, (article, summary, group_id, group_topic) in enumerate(summaries):
-            embedding_list = embeddings[i].tolist() if embeddings is not None else None
-            db.save_summary(batch_id, article, summary, group_id, group_topic, embedding_list)
-            if article.source_type == "email":
-                db.mark_email_processed(article.source_id)
-        logger.info("データベースへの保存が完了しました。")
-    else:
-        logger.info("[Dry-Run] データベースへの保存をスキップしました。")
-
-    if run_discord:
-        discord_out = DiscordOutput()
-        discord_out.post(digest, only_summaries)
-        logger.info("Discordへの送信が完了しました。")
-    else:
-        logger.info("[Dry-Run] Discordへの送信をスキップしました。")
-        print("\n=== ダイジェスト結果 ===")
-        print(digest.overview)
-        for c in digest.categories:
-            bullets = "\n".join(f"  • {a}" for a in c.articles)
-            print(f"\n[{c.category}] ({c.article_count}件)\n{bullets}")
-
-    logger.info("プロセス完了")
 
 if __name__ == "__main__":
     main()

--- a/outputs/database.py
+++ b/outputs/database.py
@@ -13,7 +13,7 @@ logger = get_logger(__name__)
 class Database:
     def __init__(self, db_path: str | None = None):
         if db_path is None:
-            db_path = config["database"]["path"]
+            db_path = config.database.path
             
         self.db_path = Path(db_path)
         # 必要なディレクトリの作成

--- a/outputs/discord_output.py
+++ b/outputs/discord_output.py
@@ -10,11 +10,11 @@ logger = get_logger(__name__)
 
 class DiscordOutput:
     def __init__(self):
-        discord_cfg = config.get("discord", {})
-        self.webhook_url = discord_cfg.get("webhook_url")
-        self.embed_color = discord_cfg.get("embed_color", 0x5865F2)
-        self.footer_text = discord_cfg.get("footer_text", "")
-        self.post_individual_articles = discord_cfg.get("post_individual_articles", True)
+        discord_cfg = config.discord
+        self.webhook_url = discord_cfg.webhook_url
+        self.embed_color = discord_cfg.embed_color
+        self.footer_text = discord_cfg.footer_text
+        self.post_individual_articles = discord_cfg.post_individual_articles
 
     def post(self, digest: DigestResult, summaries: List[ArticleSummary]):
         if not self.webhook_url:

--- a/pipeline.py
+++ b/pipeline.py
@@ -1,0 +1,257 @@
+"""Pipeline orchestration for the News Summarizer.
+
+Exposes `run_pipeline(config, options)` as the single entrypoint.
+Internal steps are broken into small functions for clarity.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+import numpy as np
+from tqdm import tqdm
+
+import config as config_module
+from config import AppConfig
+from logger import get_logger
+from models import Article, ArticleSummary
+
+from fetchers.rss_fetcher import MinifluxFetcher
+from fetchers.email_fetcher import EmailFetcher
+from outputs.database import Database
+from outputs.discord_output import DiscordOutput
+from summarizer.grouper import group_articles, group_summaries
+from summarizer.summarizer import summarize_article
+from summarizer.digest import generate_digest
+
+logger = get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# RunOptions — frozen options object threaded through the pipeline
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class RunOptions:
+    dry_run: bool = False
+    forced_outputs: frozenset[Literal["discord", "db", "all"]] = field(
+        default_factory=frozenset
+    )
+    sources: frozenset[Literal["rss", "email", "all"]] = field(
+        default_factory=lambda: frozenset({"all"})
+    )
+    stream: bool = False
+    debug: bool = False
+
+    @property
+    def run_db(self) -> bool:
+        return not self.dry_run or "db" in self.forced_outputs or "all" in self.forced_outputs
+
+    @property
+    def run_discord(self) -> bool:
+        return not self.dry_run or "discord" in self.forced_outputs or "all" in self.forced_outputs
+
+    @property
+    def run_rss(self) -> bool:
+        return "all" in self.sources or "rss" in self.sources
+
+    @property
+    def run_email(self) -> bool:
+        return "all" in self.sources or "email" in self.sources
+
+
+# ---------------------------------------------------------------------------
+# Pipeline steps
+# ---------------------------------------------------------------------------
+
+def fetch_articles(options: RunOptions, db: Database) -> list[Article]:
+    """Fetch articles from enabled sources with per-source error isolation."""
+    articles: list[Article] = []
+
+    if options.run_rss:
+        try:
+            logger.info("RSS（Miniflux）から記事を取得中...")
+            rss_fetcher = MinifluxFetcher(dry_run=options.dry_run)
+            articles.extend(rss_fetcher.fetch())
+        except Exception as e:
+            logger.error("RSSの取得中にエラーが発生しました: %s", e, exc_info=True)
+
+    if options.run_email:
+        try:
+            logger.info("Email（POP3）から記事を取得中...")
+            email_fetcher = EmailFetcher(db)
+            articles.extend(email_fetcher.fetch())
+        except Exception as e:
+            logger.error("Emailの取得中にエラーが発生しました: %s", e, exc_info=True)
+
+    return articles
+
+
+def summarize_all(
+    articles: list[Article], options: RunOptions
+) -> list[tuple[Article, ArticleSummary]]:
+    """Summarize each article; skip failures with per-article error isolation."""
+    pairs: list[tuple[Article, ArticleSummary]] = []
+
+    if options.stream:
+        logger.info("個別記事の要約を行っています...")
+        articles_iter = articles
+    else:
+        articles_iter = tqdm(articles, desc="記事を要約中", unit="件")
+
+    for article in articles_iter:
+        try:
+            summary = summarize_article(article, stream=options.stream)
+            pairs.append((article, summary))
+        except Exception as e:
+            logger.error(
+                "記事要約中にエラーが発生しました (ID: %s): %s",
+                article.source_id,
+                e,
+                exc_info=True,
+            )
+
+    return pairs
+
+
+def group_pairs(
+    pairs: list[tuple[Article, ArticleSummary]], options: RunOptions
+) -> tuple[dict[int, tuple], np.ndarray | None]:
+    """Group articles by topic using embeddings or LLM.
+
+    Returns:
+        article_group_map: index → (group_id, topic)
+        embeddings: numpy array if embedding-based grouping was used, else None
+    """
+    article_group_map: dict[int, tuple] = {}
+    embeddings: np.ndarray | None = None
+
+    grouper_cfg = config_module.config.summarizer.steps.get("grouper")
+    use_embeddings = grouper_cfg.use_embeddings if grouper_cfg else False
+    embedding_model = config_module.config.llm.embedding_model
+
+    if use_embeddings and embedding_model:
+        logger.info("Embedding を取得中...")
+        try:
+            from summarizer.embedder import get_embeddings
+            texts = [f"{s.title} {s.summary}" for _, s in pairs]
+            embeddings = get_embeddings(texts, debug=options.debug)
+
+            logger.info("類似記事の統合を行っています（embedding）...")
+            only_summaries = [s for _, s in pairs]
+            grouping_result = group_summaries(
+                only_summaries, embeddings, stream=options.stream, debug=options.debug
+            )
+            for group in grouping_result.groups:
+                for idx in group.article_indices:
+                    article_group_map[idx] = (group.group_id, group.topic)
+        except Exception as e:
+            logger.error(
+                "Embedding グルーピング中にエラーが発生しました: %s", e, exc_info=True
+            )
+            embeddings = None
+            article_group_map = {}
+    else:
+        logger.info("類似記事の統合を行っています...")
+        try:
+            articles = [a for a, _ in pairs]
+            grouping_result = group_articles(articles, stream=options.stream)
+            for group in grouping_result.groups:
+                for idx in group.article_indices:
+                    article_group_map[idx] = (group.group_id, group.topic)
+        except Exception as e:
+            logger.error(
+                "類似記事統合中にエラーが発生しました: %s", e, exc_info=True
+            )
+            article_group_map = {}
+
+    return article_group_map, embeddings
+
+
+def build_digest(
+    pairs: list[tuple[Article, ArticleSummary]],
+    article_group_map: dict[int, tuple],
+    options: RunOptions,
+):
+    """Attach group info to summaries and generate the digest.
+
+    Returns:
+        summaries: list of (Article, ArticleSummary, group_id, group_topic)
+        digest: DigestResult
+    """
+    summaries = []
+    for i, (article, summary) in enumerate(pairs):
+        group_info = article_group_map.get(i, (None, None))
+        summaries.append((article, summary, group_info[0], group_info[1]))
+
+    logger.info("ダイジェストを生成しています...")
+    only_summaries = [s[1] for s in summaries]
+    digest = generate_digest(only_summaries, stream=options.stream)
+    return summaries, digest
+
+
+def persist_and_publish(summaries, digest, embeddings, db: Database, options: RunOptions) -> None:
+    """Save to DB and/or post to Discord based on RunOptions."""
+    logger.info("結果を保存・出力しています...")
+    only_summaries = [s[1] for s in summaries]
+
+    if options.run_db:
+        batch_id = db.create_batch(
+            total_articles=len(only_summaries), digest_text=digest.overview
+        )
+        for i, (article, summary, group_id, group_topic) in enumerate(summaries):
+            embedding_list = embeddings[i].tolist() if embeddings is not None else None
+            db.save_summary(batch_id, article, summary, group_id, group_topic, embedding_list)
+            if article.source_type == "email":
+                db.mark_email_processed(article.source_id)
+        logger.info("データベースへの保存が完了しました。")
+    else:
+        logger.info("[Dry-Run] データベースへの保存をスキップしました。")
+
+    if options.run_discord:
+        discord_out = DiscordOutput()
+        discord_out.post(digest, only_summaries)
+        logger.info("Discordへの送信が完了しました。")
+    else:
+        logger.info("[Dry-Run] Discordへの送信をスキップしました。")
+        print("\n=== ダイジェスト結果 ===")
+        print(digest.overview)
+        for c in digest.categories:
+            bullets = "\n".join(f"  • {a}" for a in c.articles)
+            print(f"\n[{c.category}] ({c.article_count}件)\n{bullets}")
+
+
+# ---------------------------------------------------------------------------
+# Top-level entrypoint
+# ---------------------------------------------------------------------------
+
+def run_pipeline(config: AppConfig, options: RunOptions) -> None:
+    """Run the full fetch → summarize → group → digest → output pipeline."""
+    logger.info("プロセス開始")
+
+    db = Database()
+
+    articles = fetch_articles(options, db)
+    if not articles:
+        logger.info("新規記事はありませんでした。処理を終了します。")
+        return
+
+    logger.info("%d件の新規記事を取得しました。", len(articles))
+
+    pairs = summarize_all(articles, options)
+    if not pairs:
+        logger.warning("要約に成功した記事がありませんでした。処理を終了します。")
+        return
+
+    article_group_map, embeddings = group_pairs(pairs, options)
+
+    try:
+        summaries, digest = build_digest(pairs, article_group_map, options)
+    except Exception as e:
+        logger.error("ダイジェスト生成中にエラーが発生しました: %s", e, exc_info=True)
+        return
+
+    persist_and_publish(summaries, digest, embeddings, db, options)
+
+    logger.info("プロセス完了")

--- a/summarizer/digest.py
+++ b/summarizer/digest.py
@@ -116,7 +116,7 @@ def generate_digest(summaries: List[ArticleSummary], stream: bool = False) -> Di
 
     client = get_client()
     model = get_model_name()
-    max_length = config["summarizer"]["digest_max_length"]
+    max_length = config.summarizer.digest_max_length
     parameters, extra_body = build_step_params("digest")
 
     # カテゴリ別にグループ化

--- a/summarizer/embedder.py
+++ b/summarizer/embedder.py
@@ -3,7 +3,7 @@ import time
 import numpy as np
 from openai import OpenAI
 
-from summarizer.llm_client import _get_llm_config
+from config import config
 from logger import get_logger
 
 logger = get_logger(__name__)
@@ -25,8 +25,8 @@ def get_embeddings(texts: list[str], debug: bool = False) -> np.ndarray:
     Raises:
         ValueError: llm.embedding_model が未設定の場合
     """
-    llm_config = _get_llm_config()
-    embedding_model = llm_config.get("embedding_model")
+    llm_cfg = config.llm
+    embedding_model = llm_cfg.embedding_model
     if not embedding_model:
         raise ValueError("llm.embedding_model が設定されていません。")
 
@@ -34,8 +34,8 @@ def get_embeddings(texts: list[str], debug: bool = False) -> np.ndarray:
         logger.debug("Embedding モデル: %s, 入力: %d件", embedding_model, len(texts))
 
     client = OpenAI(
-        base_url=llm_config["base_url"],
-        api_key=llm_config.get("api_key", "ollama"),
+        base_url=llm_cfg.base_url,
+        api_key=llm_cfg.api_key,
     )
 
     start = time.perf_counter()

--- a/summarizer/grouper.py
+++ b/summarizer/grouper.py
@@ -27,10 +27,10 @@ def group_articles(articles: List[Article], stream: bool = False) -> GroupingRes
         return GroupingResult(groups=[])
 
     step_cfg = get_step_config("grouper")
-    use_embeddings = step_cfg.get("use_embeddings", False)
+    use_embeddings = step_cfg.use_embeddings
 
-    from summarizer.llm_client import _get_llm_config
-    embedding_model = _get_llm_config().get("embedding_model")
+    from config import config
+    embedding_model = config.llm.embedding_model
 
     if use_embeddings and embedding_model:
         from summarizer.embedder import get_embeddings
@@ -71,12 +71,12 @@ def group_summaries(
 
 
 def _group_with_embeddings(
-    summaries, embeddings: np.ndarray, step_cfg: dict, stream: bool, debug: bool = False
+    summaries, embeddings: np.ndarray, step_cfg, stream: bool, debug: bool = False
 ) -> GroupingResult:
     """embedding + AgglomerativeClustering でグルーピングし、LLM でトピック命名する。"""
     from sklearn.metrics.pairwise import cosine_similarity as _cosine_similarity
 
-    similarity_threshold = step_cfg.get("similarity_threshold", 0.85)
+    similarity_threshold = step_cfg.similarity_threshold
     distance_threshold = 1.0 - similarity_threshold
 
     if stream:

--- a/summarizer/llm_client.py
+++ b/summarizer/llm_client.py
@@ -2,40 +2,33 @@ import json
 import re
 from openai import OpenAI
 from config import config
+from config import SummarizerStepConfig
 from logger import get_logger
 
 logger = get_logger(__name__)
 
 
-def _get_llm_config() -> dict:
-    """LLM 設定を取得する。`llm` キーを優先し、後方互換として `ollama` にフォールバック。"""
-    return config.get("llm") or config.get("ollama", {})
-
-
 def use_structured_output() -> bool:
     """Structured Output を使用するか（デフォルト: True）。"""
-    return _get_llm_config().get("structured_output", True)
+    return config.llm.structured_output
 
 
 def get_client() -> OpenAI:
     """OpenAI 互換クライアントを初期化して返す"""
-    llm_config = _get_llm_config()
     return OpenAI(
-        base_url=llm_config["base_url"],
-        api_key=llm_config.get("api_key", "ollama"),
+        base_url=config.llm.base_url,
+        api_key=config.llm.api_key,
     )
 
 
 def get_model_name() -> str:
     """使用するモデル名を取得する"""
-    return _get_llm_config()["model"]
+    return config.llm.model
 
 
-def get_step_config(step_name: str) -> dict:
-    """指定ステップの設定辞書を返す（parameters 以外のフィールドも含む）。"""
-    summarizer_config = config.get("summarizer") or {}
-    steps_config = summarizer_config.get("steps") or {}
-    return steps_config.get(step_name) or {}
+def get_step_config(step_name: str) -> SummarizerStepConfig:
+    """指定ステップの設定を返す。未定義の場合はデフォルト値を持つ SummarizerStepConfig を返す。"""
+    return config.summarizer.steps.get(step_name, SummarizerStepConfig())
 
 
 def build_step_params(step_name: str) -> tuple[dict, dict | None]:
@@ -43,10 +36,6 @@ def build_step_params(step_name: str) -> tuple[dict, dict | None]:
 
     優先順位:
       ステップ固有設定 (summarizer.steps.<step>) > グローバル設定 (llm.*) の順にマージ。
-
-    後方互換:
-      summarizer.steps が未設定の場合は summarizer.<step>_thinking フラットキーにフォールバック。
-      設定キーは `llm` を優先し、`ollama` にフォールバック。
 
     Args:
         step_name: "grouper" | "summarizer" | "digest"
@@ -56,40 +45,33 @@ def build_step_params(step_name: str) -> tuple[dict, dict | None]:
         parameters は completion_kwargs に ** 展開して渡す。
         extra_body は None または dict（llm.extra_body の値をそのまま使用）。
     """
-    llm_config = _get_llm_config()
-    summarizer_config = config.get("summarizer") or {}
-    steps_config = summarizer_config.get("steps") or {}
-    step_config = steps_config.get(step_name) or {}
+    llm_cfg = config.llm
+    step_cfg = get_step_config(step_name)
 
     # --- parameters: グローバルをベースにステップ固有でオーバーライド ---
-    global_params = dict(llm_config.get("parameters") or {})
-    step_params_override = step_config.get("parameters", None)
-    if step_params_override is not None:
-        parameters = {**global_params, **step_params_override}
+    global_params = dict(llm_cfg.parameters)
+    if step_cfg.parameters:
+        parameters = {**global_params, **step_cfg.parameters}
     else:
         parameters = global_params
 
     # --- thinking: disable_temperature_with_thinking の判定にのみ使用 ---
-    legacy_key = f"{step_name}_thinking"
-    thinking = step_config.get(
-        "thinking",
-        summarizer_config.get(legacy_key, llm_config.get("thinking", None))
-    )
+    # Step-level thinking overrides the global llm.thinking
+    thinking = step_cfg.thinking if step_cfg.thinking is not None else llm_cfg.thinking
 
     # thinking 有効時に temperature を除外するオプション
-    if thinking and llm_config.get("disable_temperature_with_thinking", False):
+    if thinking and llm_cfg.disable_temperature_with_thinking:
         parameters.pop("temperature", None)
 
     # --- extra_body: 設定ファイルの llm.extra_body をそのまま使用 ---
-    extra_body = llm_config.get("extra_body", None)
+    extra_body = llm_cfg.extra_body
 
     return parameters, extra_body
 
 
 def _inject_thinking_token(messages: list[dict]) -> list[dict]:
     """gemma4_think: true のとき、システムプロンプト先頭に <|think|> を注入する。"""
-    llm_config = _get_llm_config()
-    if not llm_config.get("gemma4_think", False):
+    if not config.llm.gemma4_think:
         return messages
     messages = list(messages)
     for i, msg in enumerate(messages):
@@ -154,7 +136,7 @@ def call_with_retry(client, completion_kwargs, stream: bool = False):
 
 def _call_structured_with_retry(client, completion_kwargs, stream: bool = False):
     """Structured Output モード: response_format に Pydantic モデルを渡して parse する。"""
-    max_retries = _get_llm_config().get("max_retries", 3)
+    max_retries = config.llm.max_retries
     last_error: Exception | None = None
 
     completion_kwargs = dict(completion_kwargs)
@@ -182,7 +164,7 @@ def _call_structured_with_retry(client, completion_kwargs, stream: bool = False)
 
 def _call_plain_text_with_retry(client, completion_kwargs, stream: bool = False):
     """プレーンテキストモード: response_format なしで呼び出し、JSON を手動パースする。"""
-    max_retries = _get_llm_config().get("max_retries", 3)
+    max_retries = config.llm.max_retries
     last_error: Exception | None = None
 
     # response_format からモデルクラスを取り出し、kwargs から除去

--- a/summarizer/summarizer.py
+++ b/summarizer/summarizer.py
@@ -12,8 +12,8 @@ def summarize_article(article: Article, stream: bool = False) -> ArticleSummary:
     """
     client = get_client()
     model = get_model_name()
-    categories = ", ".join(config["summarizer"]["categories"])
-    max_length = config["summarizer"]["individual_max_length"]
+    categories = ", ".join(config.summarizer.categories)
+    max_length = config.summarizer.individual_max_length
 
     prompt = f"""以下の記事を読み、要約・キーワード・カテゴリ分類を行ってください。
 


### PR DESCRIPTION
## Summary

- `config.py` を辞書ベースの YAML ローダーから Pydantic `BaseModel` を用いた型安全な設定レイヤーにリファクタリング（`AppConfig` 以下の各セクションモデル、バリデーション、`reload_config()` の追加）
- `main.py` にベタ書きしていたパイプラインロジックを新規モジュール `pipeline.py` に分離し、`main.py` は CLI 引数のパースと `run_pipeline()` の呼び出しのみの薄いエントリポイントに簡素化
- 各ステップを `fetch_articles()` → `summarize_all()` → `group_pairs()` → `build_digest()` → `persist_and_publish()` に分割し、`RunOptions` frozen dataclass で実行オプションを一元管理
- `llm_client.py` 等の辞書アクセス (`config["llm"]["model"]`) を属性アクセス (`config.llm.model`) に統一し、後方互換の `ollama` キーフォールバックやレガシーキー処理を削除

### 含まれる変更

`refactor/config-validation` のコミットを含む（スーパーセット）:
- `refactor: introduce Pydantic-based type-safe configuration layer`
- `リファクタリング: main.pyを薄いCLIエントリポイントとパイプラインモジュールに分割`