### PR TITLE
call_onceを廃止しcall_with_retryに統一してパース失敗時のリトライを有効化

### DIFF
--- a/summarizer/llm_client.py
+++ b/summarizer/llm_client.py
@@ -194,51 +194,6 @@ def _call_plain_text_with_retry(client, completion_kwargs, stream: bool = False)
     raise last_error
 
 
-def call_once(client, completion_kwargs, stream: bool = False):
-    """LLM を1回だけ呼び出す（内側リトライなし）。カテゴリ検証の外側ループ用。
-
-    カテゴリ検証では外側ループが再試行を管理するため、内側リトライは不要。
-    structured_output 設定に応じてモードを切り替える点は call_with_retry と同じ。
-    """
-    if use_structured_output():
-        return _call_structured_once(client, completion_kwargs, stream)
-    else:
-        return _call_plain_text_once(client, completion_kwargs, stream)
-
-
-def _call_structured_once(client, completion_kwargs, stream: bool = False):
-    """Structured Output モード（リトライなし）。"""
-    completion_kwargs = dict(completion_kwargs)
-    completion_kwargs["messages"] = _inject_thinking_token(completion_kwargs["messages"])
-
-    if stream:
-        response = stream_completion(client, completion_kwargs)
-    else:
-        response = client.chat.completions.parse(**completion_kwargs)
-
-    parsed = response.choices[0].message.parsed
-    if not parsed:
-        raise ValueError("Failed to parse the structured output from LLM.")
-    return parsed
-
-
-def _call_plain_text_once(client, completion_kwargs, stream: bool = False):
-    """プレーンテキストモード（リトライなし）。"""
-    kwargs = dict(completion_kwargs)
-    kwargs["messages"] = _inject_thinking_token(kwargs["messages"])
-    model_class = kwargs.pop("response_format", None)
-    if model_class is None:
-        raise ValueError("response_format が指定されていません。")
-
-    kwargs["messages"] = _inject_json_instruction(kwargs["messages"], model_class)
-
-    if stream:
-        text = stream_plain_text_completion(client, kwargs)
-    else:
-        response = client.chat.completions.create(**kwargs)
-        text = response.choices[0].message.content or ""
-    return _extract_json(text, model_class)
-
 
 def stream_plain_text_completion(client, completion_kwargs) -> str:
     """ストリーミングでプレーンテキスト補完を実行し、出力しながら全文を返す。"""

--- a/summarizer/summarizer.py
+++ b/summarizer/summarizer.py
@@ -1,5 +1,5 @@
 from models import Article, ArticleSummary
-from summarizer.llm_client import get_client, get_model_name, build_step_params, call_with_retry, call_once
+from summarizer.llm_client import get_client, get_model_name, build_step_params, call_with_retry
 from config import config
 from logger import get_logger
 
@@ -46,7 +46,7 @@ def summarize_article(article: Article, stream: bool = False) -> ArticleSummary:
     last_result: ArticleSummary | None = None
 
     for attempt in range(category_max_retries + 1):
-        if attempt > 0:
+        if attempt > 0 and last_result is not None:
             logger.warning(
                 "[カテゴリ再試行 %d/%d] 記事「%s」に未定義カテゴリ「%s」が返されました。再試行します。",
                 attempt,
@@ -73,7 +73,7 @@ def summarize_article(article: Article, stream: bool = False) -> ArticleSummary:
         if extra_body:
             completion_kwargs["extra_body"] = extra_body
 
-        result: ArticleSummary = call_once(client, completion_kwargs, stream)
+        result: ArticleSummary = call_with_retry(client, completion_kwargs, stream)
 
         if result.category in categories:
             return result

--- a/tests/test_summarizer.py
+++ b/tests/test_summarizer.py
@@ -74,7 +74,7 @@ class TestSummarizeArticleCategoryRetry:
             import summarizer.summarizer as summod
             importlib.reload(summod)
 
-            with patch("summarizer.summarizer.call_once") as mock_call, \
+            with patch("summarizer.summarizer.call_with_retry") as mock_call, \
                  patch("summarizer.summarizer.get_client"), \
                  patch("summarizer.summarizer.get_model_name", return_value="test-model"), \
                  patch("summarizer.summarizer.build_step_params", return_value=({}, None)):
@@ -95,7 +95,7 @@ class TestSummarizeArticleCategoryRetry:
             import summarizer.summarizer as summod
             importlib.reload(summod)
 
-            with patch("summarizer.summarizer.call_once") as mock_call, \
+            with patch("summarizer.summarizer.call_with_retry") as mock_call, \
                  patch("summarizer.summarizer.get_client"), \
                  patch("summarizer.summarizer.get_model_name", return_value="test-model"), \
                  patch("summarizer.summarizer.build_step_params", return_value=({}, None)):
@@ -120,7 +120,7 @@ class TestSummarizeArticleCategoryRetry:
             import summarizer.summarizer as summod
             importlib.reload(summod)
 
-            with patch("summarizer.summarizer.call_once") as mock_call, \
+            with patch("summarizer.summarizer.call_with_retry") as mock_call, \
                  patch("summarizer.summarizer.get_client"), \
                  patch("summarizer.summarizer.get_model_name", return_value="test-model"), \
                  patch("summarizer.summarizer.build_step_params", return_value=({}, None)):
@@ -157,7 +157,7 @@ class TestSummarizeArticleCategoryRetry:
             import summarizer.summarizer as summod
             importlib.reload(summod)
 
-            with patch("summarizer.summarizer.call_once") as mock_call, \
+            with patch("summarizer.summarizer.call_with_retry") as mock_call, \
                  patch("summarizer.summarizer.get_client"), \
                  patch("summarizer.summarizer.get_model_name", return_value="test-model"), \
                  patch("summarizer.summarizer.build_step_params", return_value=({}, None)):
@@ -179,7 +179,7 @@ class TestSummarizeArticleCategoryRetry:
             import summarizer.summarizer as summod
             importlib.reload(summod)
 
-            with patch("summarizer.summarizer.call_once") as mock_call, \
+            with patch("summarizer.summarizer.call_with_retry") as mock_call, \
                  patch("summarizer.summarizer.get_client"), \
                  patch("summarizer.summarizer.get_model_name", return_value="test-model"), \
                  patch("summarizer.summarizer.build_step_params", return_value=({}, None)):
@@ -201,7 +201,7 @@ class TestSummarizeArticleCategoryRetry:
             import summarizer.summarizer as summod
             importlib.reload(summod)
 
-            with patch("summarizer.summarizer.call_once") as mock_call, \
+            with patch("summarizer.summarizer.call_with_retry") as mock_call, \
                  patch("summarizer.summarizer.get_client"), \
                  patch("summarizer.summarizer.get_model_name", return_value="test-model"), \
                  patch("summarizer.summarizer.build_step_params", return_value=({}, None)):


### PR DESCRIPTION
## Summary
- `call_once`（リトライなし）を廃止し、`call_with_retry`（`max_retries`回リトライあり）に統一
- これにより、LLMのJSONパース失敗（ValidationError）時にも `max_retries` 回の再試行が行われるようになった
- カテゴリ再試行ループの `last_result` にNoneガード（`last_result is not None`）を追加し、将来の例外ハンドリング変更に対する堅牢性を向上

## 変更内容
| ファイル | 変更 |
|---------|------|
| `summarizer/summarizer.py` | `call_once` → `call_with_retry` に変更、`last_result`のNoneガード追加 |
| `summarizer/llm_client.py` | `call_once`, `_call_structured_once`, `_call_plain_text_once` の3関数を削除 |
| `tests/test_summarizer.py` | 6箇所のモックパスを `call_once` → `call_with_retry` に変更 |

## テスト
全87テスト通過済み